### PR TITLE
Chore: commit-msg 훅 수정하여 주석 제외하고 커밋 메시지 검사

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -23,7 +23,6 @@ module.exports = {
     'header-max-length': [2, 'always', 72], // 제목 최대 길이 제한
   },
   ignores: [
-    (commit) => commit.startsWith('#'), // 주석으로 시작하는 커밋 메시지 무시
-    (commit) => commit.includes('Merge'), // Merge 커밋 무시
+    (commit) => commit.includes('Merge'), // Merge 커밋 무시 
   ],
 };

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# 커밋 메시지 파일 경로
+COMMIT_MSG_FILE="$1"
+
+# 주석을 제거한 커밋 메시지 임시 파일 생성
+grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^$' > "$COMMIT_MSG_FILE.tmp"
+
+# yarn을 사용하여 주석을 제외한 커밋 메시지 내용을 commitlint로 검사
+yarn commitlint --edit "$COMMIT_MSG_FILE.tmp"
+
+# 임시 파일 삭제
+rm "$COMMIT_MSG_FILE.tmp"


### PR DESCRIPTION
커밋 메시지에 주석이 포함된 경우에도 정확하게 커밋 규칙이 적용되도록 `commitlint` 설정을 업데이트했습니다.

- 기존 설정에서 '#'으로 시작하는 커밋 메시지를 검사하지 않도록 설정한 부분을 수정했습니다. 해당설정은 주석을 포함한 모든 커밋 메시지를 검사에서 제외하여 주석이 포함된 커밋 메시지의 규칙 검사가 누락되는 문제가 있었습니다.

-  ".husky/commit-msg" 스크립트를 수정하여 주석을 제거한 후, 주석이 제외된 메시지에 대해서만 "commitlint"가 규칙을 검사하도록 설정했습니다. 이를 통해 커밋 메시지 규칙이 주석을 제외한 실제 메시지에만 적용되도록 개선하였습니다.