### PR TITLE
Chore: env 변수명 변경: VITE_REACT_APP_KAKAOMAP_KEY -> VITE_KAKAOMAP_KEY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,8 @@
-version: '3'
+
 services:
   frontend:
     build: .
     ports:
       - "80:80"
     environment:
-      - VITE_REACT_APP_KAKAOMAP_KEY=${VITE_REACT_APP_KAKAOMAP_KEY}
-
-  # 백엔드 서비스는 나중에 추가할 수 있습니다
-  # backend:
-  #   build: ./backend
-  #   ports:
-  #     - "8080:8080"
+      - VITE_KAKAOMAP_KEY=${VITE_KAKAOMAP_KEY}


### PR DESCRIPTION
- frontend 서비스의 환경변수 이름을 VITE_REACT_APP_KAKAOMAP_KEY에서 VITE_KAKAOMAP_KEY로 변경
- 불필요한 주석 제거