### PR TITLE
Chore: Dockerfile을 알파인 기반 이미지로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-# Build stage
-FROM node:20 AS build
+# 빌드 단계
+FROM node:20-alpine AS build
+
 WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .
-RUN yarn build
+RUN VITE_KAKAOMAP_KEY yarn build
 
-# Production stage
-FROM nginx:stable
+# 실행 단계
+FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
- 기존 Dockerfile의 베이스 이미지를 알파인 버전으로 교체
- Node.js 및 Nginx 이미지를 알파인 버전으로 업데이트
- 이미지 크기 감소