### PR TITLE
Update commitlint.yml

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,10 +1,8 @@
 name: Commit Lint
-
 on:
   push:
     branches:
       - '**'
-
 jobs:
   commitlint:
     runs-on: ubuntu-latest
@@ -13,22 +11,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0  # 전체 히스토리 필요
-
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20'
-
       - name: Install dependencies
         run: yarn install
-
       - name: Run commitlint
         run: |
           # 현재 브랜치 이름 가져오기
-          CURRENT_BRANCH=${GITHUB_REF#refs/heads/}CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
+          CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
           
-          # 원격 브랜치 정보 업데이트
-          git fetch origin $CURRENT_BRANCH
+          echo "Current branch: $CURRENT_BRANCH"
           
           # 가장 최근의 커밋 해시 가져오기
           LATEST_COMMIT=$(git rev-parse HEAD)
@@ -39,4 +33,4 @@ jobs:
           echo "Checking commits from $FIRST_COMMIT to $LATEST_COMMIT"
           
           # commitlint 실행 (모든 커밋 검사)
-          npx commitlint --from=$FIRST_COMMIT --to=$LATEST_COMMIT --config ./.config/.commitlintrc.cjs
+          npx commitlint --from=$FIRST_COMMIT --to=$LATEST_COMMIT --config ./.config/.commitlintrc.cj


### PR DESCRIPTION
CURRENT_BRANCH 변수 설정 수정:

중복된 라인을 제거했습니다: CURRENT_BRANCH=${GITHUB_REF#refs/heads/}가 두 번 있었습니다.

디버깅을 위한 에코 명령 추가:

echo "Current branch: $CURRENT_BRANCH"를 추가하여 현재 브랜치 이름을 로그에 출력합니다.