### PR TITLE
Chore: commitlint 수정

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,38 +1,23 @@
-name: Commit Lint
-
+name: Commitlint
 on:
-  pull_request:
-    branches:
-      - '**'
   push:
-    branches:
-      - '**'
+    branches: [main, dev]
 
 jobs:
-  commitlint:
+  lint-commits:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # 공통 조상을 찾기 위해 전체 히스토리 필요
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Run commitlint
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          node-version: '18'
+      - run: npm install -g @commitlint/cli @commitlint/config-conventional
+      - name: Copy commitlint config
+        run: cp .commitlintrc.cjs commitlint.config.js
+      - name: Lint new commits
         run: |
-          # 공통 조상 찾기
-          BASE_SHA=$(git rev-parse origin/${BASE_REF})
-          HEAD_SHA=$(git rev-parse HEAD)
-          
-          # commitlint 실행
-          npx commitlint --from=${BASE_SHA} --to=${HEAD_SHA} --config ./.config/.commitlintrc.cjs
+          if [ "${{ github.event_name }}" = "push" ]; then
+            git log ${{ github.event.before }}..${{ github.event.after }} --format="%H" | xargs -I {} sh -c 'git show -s --format=%B {} | commitlint'
+          fi


### PR DESCRIPTION
main과 dev 브랜치에 대한 push 이벤트에 대해서만 실행됩니다.
Ubuntu 최신 버전에서 실행됩니다.
Node.js 18 버전을 사용합니다.
@commitlint/cli와 @commitlint/config-conventional을 전역으로 설치합니다. .commitlintrc.cjs 파일을 commitlint.config.js로 복사합니다. (commitlint가 .cjs 확장자를 인식하지 못할 수 있어서 이 단계가 필요합니다) push 이벤트의 경우, 이전 커밋부터 새 커밋까지의 범위를 검사합니다.
각 커밋 메시지를 개별적으로 commitlint로 검사합니다.